### PR TITLE
add basic association support for ABAP CDS views

### DIFF
--- a/src/native/zcl_2ui5_native_sql_console.clas.testclasses.abap
+++ b/src/native/zcl_2ui5_native_sql_console.clas.testclasses.abap
@@ -1,0 +1,903 @@
+*"* use this source file for your ABAP unit test classes
+
+class _sql_statement_t_double definition
+                              create public
+                              inheriting from sql_statement ##CLASS_FINAL.
+		
+  public section.
+
+    methods value
+              returning
+                value(r_val) type string.
+
+endclass.
+class _sql_statement_t_double implementation.
+
+  method value.
+
+    r_val = me->a_sql_statement.
+
+  endmethod.
+
+endclass.
+class _sql_statement_spy definition
+                         create public
+                         inheriting from _sql_statement_t_double ##CLASS_FINAL.
+
+  public section.
+
+    methods sole_associaton_if_any redefinition.
+
+    methods generated_join_for_association redefinition.
+
+    methods assoc_mapped_to_join_if_any redefinition.
+
+    data sole_assoc_out type string.
+
+    data generated_join_in type string.
+
+    data generated_join_out type string.
+
+    data assoc_mapped_in_1 type string.
+
+    data assoc_mapped_in_2 type string.
+
+    data assoc_mapped_out type string.
+
+endclass.
+class _sql_statement_spy implementation.
+
+  method sole_associaton_if_any.
+
+    me->sole_assoc_out = `SOLE_ASSOCIATON_IF_ANY`.
+
+    r_val = me->sole_assoc_out.
+
+  endmethod.
+  method generated_join_for_association.
+
+    me->generated_join_in = i_association.
+
+    me->generated_join_out = `GENERATED_JOIN_FOR_ASSOCIATION`.
+
+    r_val = me->generated_join_out.
+
+  endmethod.
+  method assoc_mapped_to_join_if_any.
+
+    me->assoc_mapped_in_1 = i_association.
+
+    me->assoc_mapped_in_2 = i_join.
+
+    me->assoc_mapped_out = `ASSOC_MAPPED_TO_JOIN_IF_ANY`.
+
+    r_val = me->assoc_mapped_out.
+
+  endmethod.
+
+endclass.
+class _sql_statement_stub definition
+                          create public
+                          inheriting from _sql_statement_t_double ##CLASS_FINAL.
+		
+  public section.
+
+    methods constructor
+              importing
+                i_processor type sql_statement=>t_processor
+                i_association_processor type sql_statement=>t_association_processor
+                i_sql_statement type string
+                i_data_sources type string_table optional
+                i_sole_association_return type string optional
+                i_generated_join_return type string optional
+                i_assoc_mapped_return type string optional
+              raising
+                cx_sql_exception.
+
+    methods data_sources redefinition.
+
+    methods sole_associaton_if_any redefinition.
+
+    methods generated_join_for_association redefinition.
+
+    methods assoc_mapped_to_join_if_any redefinition.
+
+  protected section.
+
+    data a_data_source_coll type string_table.
+
+    data a_sole_association_return type string.
+
+    data a_generated_join_return type string.
+
+    data an_assoc_mapped_return type string.
+
+endclass.
+class _sql_statement_stub implementation.
+
+  method constructor.
+
+    super->constructor( i_processor = i_processor
+                        i_association_processor = i_association_processor
+                        i_sql_statement = i_sql_statement ).
+
+    me->a_data_source_coll = i_data_sources.
+
+    me->a_sole_association_return = i_sole_association_return.
+
+    me->a_generated_join_return = i_generated_join_return.
+
+    me->an_assoc_mapped_return = i_assoc_mapped_return.
+
+  endmethod.
+  method data_sources.
+
+    r_val = cond #( when me->a_data_source_coll is initial
+                    then super->data_sources( )
+                    else me->a_data_source_coll ).
+
+  endmethod.
+  method assoc_mapped_to_join_if_any.
+
+    r_val = cond #( when me->an_assoc_mapped_return is initial
+                    then super->assoc_mapped_to_join_if_any( i_association = i_association
+                                                             i_join = i_join )
+                    else me->an_assoc_mapped_return ).
+
+  endmethod.
+  method generated_join_for_association.
+
+    r_val = cond #( when me->a_generated_join_return is initial
+                    then super->generated_join_for_association( i_association )
+                    else me->a_generated_join_return ).
+
+  endmethod.
+  method sole_associaton_if_any.
+
+    r_val = cond #( when me->a_sole_association_return is initial
+                    then super->sole_associaton_if_any( )
+                    else me->a_sole_association_return ).
+
+  endmethod.
+
+endclass.
+class _cl_sql_statement_spy definition
+                            create public
+                            inheriting from cl_sql_statement ##CLASS_FINAL.
+		
+  public section.
+
+    methods execute_query redefinition.
+
+    data execute_query_in type string.
+
+endclass.
+class _cl_sql_statement_spy implementation.
+
+  method execute_query.
+
+    me->execute_query_in = statement.
+
+    result_set = super->execute_query( `select 1 as test from dummy;` ) ##NO_TEXT.
+
+  endmethod.
+
+endclass.
+class association_processor_dummy definition
+                                  create public ##CLASS_FINAL.
+
+  public section.
+
+    interfaces: zif_association_processor.
+
+endclass.
+class association_processor_dummy implementation.
+
+  method zif_association_processor~map_association_to_join.
+
+    return.
+
+  endmethod.
+
+endclass.
+class association_processor_spy definition
+                                create public ##CLASS_FINAL.
+		
+  public section.
+
+    interfaces: zif_association_processor.
+
+    data data_sources type zif_association_processor=>t_data_sources.
+
+    data association type string.
+
+endclass.
+class association_processor_spy implementation.
+
+  method zif_association_processor~map_association_to_join.
+
+    me->data_sources = i_potential_data_sources.
+
+    me->association = i_association.
+
+  endmethod.
+
+endclass.
+
+"! Tests for {@link sql_statement}
+"! <br/>
+"! ABAP has a ridiculous character limitation for names so all the names of the tests are useless, have fun
+class _t_sql_statement definition
+                       create private
+                       final
+                       for testing
+                       duration short
+                       risk level harmless.
+
+  private section.
+
+    types: begin of t_basic,
+             field type ref to sql_statement,
+             field_w_alias type ref to sql_statement,
+             qualified_field type ref to sql_statement,
+             qualified_field_w_alias type ref to sql_statement,
+           end of t_basic,
+           begin of t_simple_path_expressions,
+             field type ref to sql_statement,
+             field_w_alias type ref to sql_statement,
+             qualified_field type ref to sql_statement,
+             qualified_field_w_alias type ref to sql_statement,
+             field_with_attr type ref to sql_statement,
+             qualified_field_w_attr type ref to sql_statement,
+             field_with_attr_w_alias type ref to sql_statement,
+             qualified_field_w_attr_w_alias type ref to sql_statement,
+           end of t_simple_path_expressions,
+           begin of t_complex_path_expressions,
+             field type ref to sql_statement,
+             field_w_alias type ref to sql_statement,
+             qualified_field type ref to sql_statement,
+             qualified_field_w_alias type ref to sql_statement,
+             field_with_attr type ref to sql_statement,
+             qualified_field_w_attr type ref to sql_statement,
+             field_with_attr_w_alias type ref to sql_statement,
+             qualified_field_w_attr_w_alias type ref to sql_statement,
+             field_with_several_assocs type ref to sql_statement,
+           end of t_complex_path_expressions,
+           begin of t_path_expressions,
+             simple type _t_sql_statement=>t_simple_path_expressions,
+             complex type _t_sql_statement=>t_complex_path_expressions,
+           end of t_path_expressions,
+           begin of t_statements,
+             begin of non_delimited,
+               path_expressions type _t_sql_statement=>t_path_expressions,
+               basic type _t_sql_statement=>t_basic,
+             end of non_delimited,
+             begin of delimited,
+               path_expressions type _t_sql_statement=>t_path_expressions,
+               basic type _t_sql_statement=>t_basic,
+             end of delimited,
+           end of t_statements.
+
+    methods constructor
+              raising
+                cx_sql_exception ##RELAX.
+
+    methods assert_gt_1_assoc_throws_exc
+              importing
+                i_previous type any
+                i_name type string optional.
+
+    methods assert_le_1_assoc_no_exc
+              importing
+                i_previous type any
+                i_name type string optional.
+
+    methods assert_1_assoc_returned
+              importing
+                i_previous type any
+                i_name type string optional
+              raising
+                cx_sql_exception.
+
+    methods assert_le_1_assoc_rets_empty
+              importing
+                i_previous type any
+                i_name type string optional
+              raising
+                cx_sql_exception.
+
+    "! <p class="shorttext synchronized" lang="EN">TOP or LIMIT clause</p>
+    "! {@link sql_statement.METH:add_limit_if_none} should respect the original statement
+    methods with_row_cap_does_nothing for testing raising cx_static_check.
+
+    "! <p class="shorttext synchronized" lang="EN">No TOP or LIMIT clause</p>
+    "! {@link sql_statement.METH:add_limit_if_none} should add a limit clause at the end of the original statement
+    methods without_row_cap_adds_limit for testing raising cx_static_check.
+
+    methods execute_calls_methods for testing raising cx_static_check.
+
+    methods execute_uses_original for testing raising cx_static_check.
+
+    methods generated_join_calls_methods for testing raising cx_static_check.
+
+    methods sole_assoc_throws_for_compl_pe for testing raising cx_static_check.
+
+    methods sole_assoc_no_exc_for_simpl_pe for testing raising cx_static_check.
+
+    methods sole_assoc_throws_for_non_u_pe for testing raising cx_static_check.
+
+    methods sole_assoc_no_exc_for_u_pe for testing raising cx_static_check.
+
+    methods sole_assoc_returns_u_pe for testing raising cx_static_check.
+
+    methods sole_assoc_ret_empty_for_no_pe for testing raising cx_static_check.
+
+    methods data_sources_returned for testing raising cx_static_check.
+
+    methods assoc_mapping_added for testing raising cx_static_check.
+
+    data statements type _t_sql_statement=>t_statements.
+
+endclass.
+class _t_sql_statement implementation.
+
+  method constructor.
+
+    data(assoc_proc) = new zcl_association_processor( ).
+
+    me->statements = value #( non_delimited = value #( basic = value #( field = new sql_statement( i_sql_statement = `SELECT field,`
+                                                                                                   i_processor = new cl_sql_statement( )
+                                                                                                   i_association_processor = assoc_proc )
+                                                                        field_w_alias = new sql_statement( i_sql_statement = `SELECT field AS f,`
+                                                                                                           i_processor = new cl_sql_statement( )
+                                                                                                           i_association_processor = assoc_proc )
+                                                                        qualified_field = new sql_statement( i_sql_statement = `SELECT dbtab.field,`
+                                                                                                             i_processor = new cl_sql_statement( )
+                                                                                                             i_association_processor = assoc_proc )
+                                                                        qualified_field_w_alias = new sql_statement( i_sql_statement = `SELECT dbtab.field AS f,`
+                                                                                                                     i_processor = new cl_sql_statement( )
+                                                                                                                     i_association_processor = assoc_proc ) )
+                                                       path_expressions = value #( simple = value #( field = new sql_statement( i_sql_statement = `SELECT _assoc.field,`
+                                                                                                                                i_processor = new cl_sql_statement( )
+                                                                                                                                i_association_processor = assoc_proc )
+                                                                                                     field_w_alias = new sql_statement( i_sql_statement = `SELECT _assoc.field AS f,`
+                                                                                                                                        i_processor = new cl_sql_statement( )
+                                                                                                                                        i_association_processor = assoc_proc )
+                                                                                                     qualified_field = new sql_statement( i_sql_statement = `SELECT entity._assoc.field,`
+                                                                                                                                          i_processor = new cl_sql_statement( )
+                                                                                                                                          i_association_processor = assoc_proc )
+                                                                                                     qualified_field_w_alias = new sql_statement( i_sql_statement = `SELECT entity._assoc.field AS f,`
+                                                                                                                                                  i_processor = new cl_sql_statement( )
+                                                                                                                                                  i_association_processor = assoc_proc )
+                                                                                                     field_with_attr = new sql_statement( i_sql_statement = `SELECT _assoc[ asdfa kljkl ].field,`
+                                                                                                                                          i_processor = new cl_sql_statement( )
+                                                                                                                                          i_association_processor = assoc_proc )
+                                                                                                     qualified_field_w_attr = new sql_statement( i_sql_statement = `SELECT entity._assoc[ asdfa kljkl ].field,`
+                                                                                                                                                 i_processor = new cl_sql_statement( )
+                                                                                                                                                 i_association_processor = assoc_proc )
+                                                                                                     field_with_attr_w_alias = new sql_statement( i_sql_statement = `SELECT _assoc[ asdfa kljkl ].field AS f,`
+                                                                                                                                                  i_processor = new cl_sql_statement( )
+                                                                                                                                                  i_association_processor = assoc_proc )
+                                                                                                     qualified_field_w_attr_w_alias = new sql_statement( i_sql_statement = `SELECT entity._assoc[ asdfa kljkl ].field AS f,`
+                                                                                                                                                         i_processor = new cl_sql_statement( )
+                                                                                                                                                         i_association_processor = assoc_proc ) )
+                                                                                   complex = value #( field = new sql_statement( i_sql_statement = `SELECT _assoc1._assoc2.field,`
+                                                                                                                                 i_processor = new cl_sql_statement( )
+                                                                                                                                 i_association_processor = assoc_proc )
+                                                                                                      field_w_alias = new sql_statement( i_sql_statement = `SELECT _assoc1._assoc2.field AS f,`
+                                                                                                                                         i_processor = new cl_sql_statement( )
+                                                                                                                                         i_association_processor = assoc_proc )
+                                                                                                      qualified_field = new sql_statement( i_sql_statement = `SELECT entity._assoc1._assoc2.field,`
+                                                                                                                                           i_processor = new cl_sql_statement( )
+                                                                                                                                           i_association_processor = assoc_proc )
+                                                                                                      qualified_field_w_alias = new sql_statement( i_sql_statement = `SELECT entity._assoc1._assoc2.field AS f,`
+                                                                                                                                                   i_processor = new cl_sql_statement( )
+                                                                                                                                                   i_association_processor = assoc_proc )
+                                                                                                      field_with_attr = new sql_statement( i_sql_statement = `SELECT _assoc1[ asdfa kljkl ]._assoc2[ asdfa kljkl ].field,`
+                                                                                                                                           i_processor = new cl_sql_statement( )
+                                                                                                                                           i_association_processor = assoc_proc )
+                                                                                                      qualified_field_w_attr = new sql_statement( i_sql_statement = `SELECT entity._assoc1[ asdfa kljkl ]._assoc2[ asdfa kljkl ].field,`
+                                                                                                                                                  i_processor = new cl_sql_statement( )
+                                                                                                                                                  i_association_processor = assoc_proc )
+                                                                                                      field_with_attr_w_alias = new sql_statement( i_sql_statement = `SELECT _assoc1[ asdfa kljkl ]._assoc2[ asdfa kljkl ].field AS f,`
+                                                                                                                                                   i_processor = new cl_sql_statement( )
+                                                                                                                                                   i_association_processor = assoc_proc )
+                                                                                                      qualified_field_w_attr_w_alias = new sql_statement( i_sql_statement = `SELECT entity._assoc1[ asdfa kljkl ]._assoc2[ asdfa kljkl ].field AS f,`
+                                                                                                                                                          i_processor = new cl_sql_statement( )
+                                                                                                                                                          i_association_processor = assoc_proc )
+                                                                                                      field_with_several_assocs = new sql_statement( i_sql_statement = `SELECT _assoc1._assoc2._assoc3._assoc4.field,`
+                                                                                                                                                     i_processor = new cl_sql_statement( )
+                                                                                                                                                     i_association_processor = assoc_proc ) ) ) )
+                              delimited = value #( basic = value #( field = new sql_statement( i_sql_statement = `SELECT "field",`
+                                                                                               i_processor = new cl_sql_statement( )
+                                                                                               i_association_processor = assoc_proc )
+                                                                    field_w_alias = new sql_statement( i_sql_statement = `SELECT "field" AS "f",`
+                                                                                                       i_processor = new cl_sql_statement( )
+                                                                                                       i_association_processor = assoc_proc )
+                                                                    qualified_field = new sql_statement( i_sql_statement = `SELECT "dbtab"."field",`
+                                                                                                         i_processor = new cl_sql_statement( )
+                                                                                                         i_association_processor = assoc_proc )
+                                                                    qualified_field_w_alias = new sql_statement( i_sql_statement = `SELECT "dbtab"."field" AS "f",`
+                                                                                                                 i_processor = new cl_sql_statement( )
+                                                                                                                 i_association_processor = assoc_proc ) )
+                                                   path_expressions = value #( simple = value #( field = new sql_statement( i_sql_statement = `SELECT "_assoc"."field",`
+                                                                                                                            i_processor = new cl_sql_statement( )
+                                                                                                                            i_association_processor = assoc_proc )
+                                                                                                 field_w_alias = new sql_statement( i_sql_statement = `SELECT "_assoc"."field" AS "f",`
+                                                                                                                                    i_processor = new cl_sql_statement( )
+                                                                                                                                    i_association_processor = assoc_proc )
+                                                                                                 qualified_field = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc"."field",`
+                                                                                                                                      i_processor = new cl_sql_statement( )
+                                                                                                                                      i_association_processor = assoc_proc )
+                                                                                                 qualified_field_w_alias = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc"."field" AS "f",`
+                                                                                                                                              i_processor = new cl_sql_statement( )
+                                                                                                                                              i_association_processor = assoc_proc )
+                                                                                                 field_with_attr = new sql_statement( i_sql_statement = `SELECT "_assoc"[ asdfa kljkl ]."field",`
+                                                                                                                                      i_processor = new cl_sql_statement( )
+                                                                                                                                      i_association_processor = assoc_proc )
+                                                                                                 qualified_field_w_attr = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc"[ asdfa kljkl ]."field" AS "f",`
+                                                                                                                                             i_processor = new cl_sql_statement( )
+                                                                                                                                             i_association_processor = assoc_proc )
+                                                                                                 field_with_attr_w_alias = new sql_statement( i_sql_statement = `SELECT "_assoc"[ asdfa kljkl ]."field" AS "f",`
+                                                                                                                                              i_processor = new cl_sql_statement( )
+                                                                                                                                              i_association_processor = assoc_proc )
+                                                                                                 qualified_field_w_attr_w_alias = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc"[ asdfa kljkl ]."field" AS "f",`
+                                                                                                                                                     i_processor = new cl_sql_statement( )
+                                                                                                                                                     i_association_processor = assoc_proc ) )
+                                                                               complex = value #( field = new sql_statement( i_sql_statement = `SELECT "_assoc1"."_assoc2"."field",`
+                                                                                                                             i_processor = new cl_sql_statement( )
+                                                                                                                             i_association_processor = assoc_proc )
+                                                                                                  field_w_alias = new sql_statement( i_sql_statement = `SELECT "_assoc1"."_assoc2"."field" AS "f",`
+                                                                                                                                     i_processor = new cl_sql_statement( )
+                                                                                                                                     i_association_processor = assoc_proc )
+                                                                                                  qualified_field = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc1"."_assoc2"."field",`
+                                                                                                                                       i_processor = new cl_sql_statement( )
+                                                                                                                                       i_association_processor = assoc_proc )
+                                                                                                  qualified_field_w_alias = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc1"."_assoc2"."field" AS "f",`
+                                                                                                                                               i_processor = new cl_sql_statement( )
+                                                                                                                                               i_association_processor = assoc_proc )
+                                                                                                  field_with_attr = new sql_statement( i_sql_statement = `SELECT "_assoc1"[ asdfa kljkl ]."_assoc2"[ asdfa kljkl ]."field",`
+                                                                                                                                       i_processor = new cl_sql_statement( )
+                                                                                                                                       i_association_processor = assoc_proc )
+                                                                                                  qualified_field_w_attr = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc1"[ asdfa kljkl ]."_assoc2"[ asdfa kljkl ]."field",`
+                                                                                                                                              i_processor = new cl_sql_statement( )
+                                                                                                                                              i_association_processor = assoc_proc )
+                                                                                                  field_with_attr_w_alias = new sql_statement( i_sql_statement = `SELECT "_assoc1"[ asdfa kljkl ]."_assoc2"[ asdfa kljkl ]."field" AS "f",`
+                                                                                                                                               i_processor = new cl_sql_statement( )
+                                                                                                                                               i_association_processor = assoc_proc )
+                                                                                                  qualified_field_w_attr_w_alias = new sql_statement( i_sql_statement = `SELECT "entity"."_assoc1"[ asdfa kljkl ]."_assoc2"[ asdfa kljkl ]."field" AS "f",`
+                                                                                                                                                      i_processor = new cl_sql_statement( )
+                                                                                                                                                      i_association_processor = assoc_proc )
+                                                                                                  field_with_several_assocs = new sql_statement( i_sql_statement = `SELECT "_assoc1"."_assoc2"."_assoc3"."_assoc4"."field",`
+                                                                                                                                                 i_processor = new cl_sql_statement( )
+                                                                                                                                                 i_association_processor = assoc_proc ) ) ) ) ).
+
+  endmethod.
+  method assert_gt_1_assoc_throws_exc.
+
+    data(type) = cl_abap_typedescr=>describe_by_data( i_previous ).
+
+    if type->kind eq cl_abap_typedescr=>kind_ref.
+
+      try.
+
+        "act
+        cast sql_statement( i_previous )->sole_associaton_if_any( ).
+
+        "assert
+        cl_abap_unit_assert=>fail( msg = |{ i_name }->SOLE_ASSOCIATON_IF_ANY( ) should throw an exception|
+                                   quit = if_abap_unit_constant=>quit-no ).
+
+      catch cx_sql_exception ##NO_HANDLER.
+
+      endtry.
+
+    else.
+
+      loop at cast cl_abap_structdescr( type )->get_components( ) reference into data(component).
+
+        assign component component->*-name of structure i_previous to field-symbol(<component>).
+
+        assert_gt_1_assoc_throws_exc( i_previous = <component>
+                                      i_name = |{ i_name }-{ component->*-name }| ).
+
+      endloop.
+
+    endif.
+
+  endmethod.
+  method assert_le_1_assoc_no_exc.
+
+    data(type) = cl_abap_typedescr=>describe_by_data( i_previous ).
+
+    if type->kind eq cl_abap_typedescr=>kind_ref.
+
+      try.
+
+        "act
+        cast sql_statement( i_previous )->sole_associaton_if_any( ).
+
+      catch cx_sql_exception.
+
+        "assert
+        cl_abap_unit_assert=>fail( msg = |{ i_name }->SOLE_ASSOCIATON_IF_ANY( ) should not throw an exception|
+                                   quit = if_abap_unit_constant=>quit-no ).
+
+      endtry.
+
+    else.
+
+      loop at cast cl_abap_structdescr( type )->get_components( ) reference into data(component).
+
+        assign component component->*-name of structure i_previous to field-symbol(<component>).
+
+        assert_le_1_assoc_no_exc( i_previous = <component>
+                                  i_name = |{ i_name }-{ component->*-name }| ).
+
+      endloop.
+
+    endif.
+
+  endmethod.
+  method assert_1_assoc_returned.
+
+    data(type) = cl_abap_typedescr=>describe_by_data( i_previous ).
+
+    if type->kind eq cl_abap_typedescr=>kind_ref.
+
+      "act & assert
+      cl_abap_unit_assert=>assert_not_initial( act = cast sql_statement( i_previous )->sole_associaton_if_any( )
+                                               msg = |{ i_name }->SOLE_ASSOCIATON_IF_ANY( ) should return the found path expression|
+                                               quit = if_abap_unit_constant=>quit-no ).
+
+    else.
+
+      loop at cast cl_abap_structdescr( type )->get_components( ) reference into data(component).
+
+        assign component component->*-name of structure i_previous to field-symbol(<component>).
+
+        assert_1_assoc_returned( i_previous = <component>
+                                 i_name = |{ i_name }-{ component->*-name }| ).
+
+      endloop.
+
+    endif.
+
+  endmethod.
+  method assert_le_1_assoc_rets_empty.
+
+    data(type) = cl_abap_typedescr=>describe_by_data( i_previous ).
+
+    if type->kind eq cl_abap_typedescr=>kind_ref.
+
+      "act & assert
+      cl_abap_unit_assert=>assert_initial( act = cast sql_statement( i_previous )->sole_associaton_if_any( )
+                                           msg = |{ i_name }->SOLE_ASSOCIATON_IF_ANY( ) should return an empty string|
+                                           quit = if_abap_unit_constant=>quit-no ).
+
+    else.
+
+      loop at cast cl_abap_structdescr( type )->get_components( ) reference into data(component).
+
+        assign component component->*-name of structure i_previous to field-symbol(<component>).
+
+        assert_le_1_assoc_rets_empty( i_previous = <component>
+                                      i_name = |{ i_name }-{ component->*-name }| ).
+
+      endloop.
+
+    endif.
+
+  endmethod.
+  method sole_assoc_throws_for_non_u_pe.
+
+    "arrange
+    data(statements) = value string_table( ( `SELECT entity._assocA.fieldA1, "_assocB"."fieldB1",` )
+                                           ( `SELECT entity._assocA[ asdf ].fieldA1 AS f, _assocB.fieldB1,` )
+                                           ( `SELECT entity._assocA.fieldA1, entity.field, entity._assocB.fieldB1,` )
+                                           ( `SELECT entity._assocA.fieldA1, entity._assocA[ inner where ].fieldA2,` ) ).
+
+    loop at statements reference into data(statement).
+
+      try.
+
+        "act
+        new sql_statement( i_sql_statement = statement->*
+                           i_association_processor = new zcl_association_processor( )
+                           i_processor = new cl_sql_statement( ) )->sole_associaton_if_any( ).
+
+        "assert
+        cl_abap_unit_assert=>fail( quit = if_abap_unit_constant=>quit-no
+                                   msg = |'{ statement->* }' has more than one unique path expression and it should throw an exception| ).
+
+      catch cx_sql_exception ##NO_HANDLER.
+
+      endtry.
+
+    endloop.
+
+  endmethod.
+  method sole_assoc_no_exc_for_u_pe.
+
+    "arrange
+    data(statements) = value string_table( ( `SELECT entity._assocA.fieldA1, "_assocA"."fieldA2",` )
+                                           ( `SELECT _assocA.fieldA1 AS f, entity._assocA.fieldA2,` )
+                                           ( `SELECT _assocA.field,` )
+                                           ( `SELECT field,` )
+                                           ( `SELECT entity._assocA.fieldA1, entity.field, entity._assocA.fieldA2,` )
+                                           ( `SELECT entity._assocA[ inner where ].fieldA1, entity._assocA[ inner where ].fieldA2,` ) ).
+
+    loop at statements reference into data(statement).
+
+      try.
+
+        "act
+        new sql_statement( i_sql_statement = statement->*
+                           i_association_processor = new zcl_association_processor( )
+                           i_processor = new cl_sql_statement( ) )->sole_associaton_if_any( ).
+
+      catch cx_sql_exception.
+
+        "assert
+        cl_abap_unit_assert=>fail( quit = if_abap_unit_constant=>quit-no
+                                   msg = |'{ statement->* }' has only one unique path expression and should not throw exception| ).
+
+      endtry.
+
+    endloop.
+
+  endmethod.
+  method with_row_cap_does_nothing.
+
+    "arrange
+    data(assoc_proc) = new zcl_association_processor( ).
+
+    data(statements) = value string_table( ( `SELECT TOP 1 * FROM dbtab;` )
+                                           ( |SELECT{ cl_abap_char_utilities=>cr_lf }TOP{ cl_abap_char_utilities=>cr_lf }1{ cl_abap_char_utilities=>cr_lf }*{ cl_abap_char_utilities=>cr_lf }FROM dbtab| )
+                                           ( `SELECT * FROM dbtab LIMIT 1;` )
+                                           ( |SELECT * FROM dbtab{ cl_abap_char_utilities=>cr_lf }LIMIT{ cl_abap_char_utilities=>cr_lf }1| ) ).
+
+    loop at statements reference into data(statement).
+
+      "act & assert
+      cl_abap_unit_assert=>assert_equals( act = cast _sql_statement_t_double( new _sql_statement_t_double( i_sql_statement = statement->*
+                                                                                                           i_processor = new cl_sql_statement( )
+                                                                                                           i_association_processor = assoc_proc )->add_limit_if_none( 1 ) )->value( )
+                                          exp = cast _sql_statement_t_double( new _sql_statement_t_double( i_sql_statement = statement->*
+                                                                                                           i_processor = new cl_sql_statement( )
+                                                                                                           i_association_processor = assoc_proc ) )->value( )
+                                          quit = if_abap_unit_constant=>quit-no
+                                          msg = |'{ statement->* }' modified unnecessarily| ).
+
+    endloop.
+
+  endmethod.
+  method without_row_cap_adds_limit.
+
+    "arrange
+    data(statements) = value string_table( ( `SELECT * FROM dbtab;` )
+                                           ( |SELECT{ cl_abap_char_utilities=>cr_lf }*{ cl_abap_char_utilities=>cr_lf }FROM{ cl_abap_char_utilities=>cr_lf }dbtab{ cl_abap_char_utilities=>cr_lf }| ) ).
+
+    loop at statements reference into data(statement).
+
+      data(max_no_of_rows) = cl_abap_random_int=>create( seed = conv #( cl_abap_context_info=>get_system_time( ) )
+                                                         min = 1 )->get_next( ).
+
+      "act & assert
+      cl_abap_unit_assert=>assert_char_cp( act = cast _sql_statement_t_double( new _sql_statement_t_double( i_sql_statement = statement->*
+                                                                                                            i_association_processor = new zcl_association_processor( )
+                                                                                                            i_processor = new cl_sql_statement( ) )->add_limit_if_none( max_no_of_rows ) )->value( )
+                                           exp = |* LIMIT { max_no_of_rows };|
+                                           quit = if_abap_unit_constant=>quit-no
+                                           msg = |'{ statement->* }' should have added a LIMIT clause| ).
+
+    endloop.
+
+  endmethod.
+  method execute_calls_methods.
+
+    "arrange
+    data(processor) = new _cl_sql_statement_spy( ).
+
+    data(statement) = new _sql_statement_spy( i_processor = processor
+                                              i_association_processor = new zcl_association_processor( )
+                                              i_sql_statement = `test` ).
+
+    "act
+    statement->execute( ).
+
+    "assert
+    cl_abap_unit_assert=>assert_true( act = xsdbool( statement->sole_assoc_out eq statement->generated_join_in
+                                                     and ( statement->sole_assoc_out eq statement->assoc_mapped_in_1 and statement->generated_join_out eq statement->assoc_mapped_in_2 )
+                                                     and statement->assoc_mapped_out eq processor->execute_query_in )
+                                      msg = `ASSOC_MAPPED_TO_JOIN_IF_ANY should use result of GENERATED_JOIN_FOR_ASSOCIATION, which should in turn use result of SOLE_ASSOCIATON_IF_ANY` ).
+
+  endmethod.
+  method execute_uses_original.
+
+    "arrange
+    data(original_statement) = `select 1 as "Test" from DUMMY;`.
+
+    data(processor) = new _cl_sql_statement_spy( ).
+
+    data(statement) = new _sql_statement_stub( i_processor = processor
+                                               i_association_processor = new association_processor_dummy( )
+                                               i_sql_statement = original_statement
+                                               i_assoc_mapped_return = value #( ) ).
+
+    "act
+    statement->execute( ).
+
+    "assert
+    cl_abap_unit_assert=>assert_equals( act = processor->execute_query_in
+                                        exp = original_statement
+                                        msg = `Since ASSOC_MAPPED_TO_JOIN_IF_ANY returned empty, we use the original statement` ). "this way we let it crash if it was wrong
+
+  endmethod.
+  method generated_join_calls_methods.
+
+    "arrange
+    data(assoc_proc) = new association_processor_spy( ).
+
+    data(data_sources) = value string_table( ( `6` )
+                                             ( `J` ) ).
+
+    data(statement) = new _sql_statement_stub( i_processor = value #( )
+                                               i_association_processor = assoc_proc
+                                               i_sql_statement = `test`
+                                               i_data_sources = data_sources ).
+
+    data(association) = `asdfasdfasdf`.
+
+    "act
+    statement->generated_join_for_association( association ).
+
+    "assert
+    cl_abap_unit_assert=>assert_true( act = xsdbool( assoc_proc->association eq association
+                                                     and assoc_proc->data_sources eq conv zif_association_processor=>t_data_sources( data_sources ) )
+                                      msg = `GENERATED_JOIN_FOR_ASSOCIATION calls AN_ASSOCIATION_PROCESSOR->MAP_ASSOCIATION_TO_JOIN using the result of DATA_SOURCES` ).
+
+  endmethod.
+  method sole_assoc_throws_for_compl_pe.
+
+    assert_gt_1_assoc_throws_exc( i_previous = me->statements-delimited-path_expressions-complex
+                                  i_name = `STATEMENTS-DELIMITED-PATH_EXPRESSIONS-COMPLEX` ).
+
+    assert_gt_1_assoc_throws_exc( i_previous = me->statements-non_delimited-path_expressions-complex
+                                  i_name = `STATEMENTS-NON_DELIMITED-PATH_EXPRESSIONS-COMPLEX` ).
+
+  endmethod.
+  method sole_assoc_no_exc_for_simpl_pe.
+
+    assert_le_1_assoc_no_exc( i_previous = me->statements-delimited-basic
+                              i_name = `STATEMENTS-DELIMITED-BASIC` ).
+
+    assert_le_1_assoc_no_exc( i_previous = me->statements-non_delimited-basic
+                              i_name = `STATEMENTS-NON_DELIMITED-BASIC` ).
+
+    assert_le_1_assoc_no_exc( i_previous = me->statements-delimited-path_expressions-simple
+                              i_name = `STATEMENTS-DELIMITED-PATH_EXPRESSIONS-SIMPLE` ).
+
+    assert_le_1_assoc_no_exc( i_previous = me->statements-non_delimited-path_expressions-simple
+                              i_name = `STATEMENTS-NON_DELIMITED-PATH_EXPRESSIONS-SIMPLE` ).
+
+  endmethod.
+  method sole_assoc_returns_u_pe.
+
+    assert_1_assoc_returned( i_previous = me->statements-delimited-path_expressions-simple
+                             i_name = `STATEMENTS-DELIMITED-PATH_EXPRESSIONS-SIMPLE` ).
+
+    assert_1_assoc_returned( i_previous = me->statements-non_delimited-path_expressions-simple
+                             i_name = `STATEMENTS-NON_DELIMITED-PATH_EXPRESSIONS-SIMPLE` ).
+
+  endmethod.
+  method sole_assoc_ret_empty_for_no_pe.
+
+    assert_le_1_assoc_rets_empty( i_previous = me->statements-delimited-basic
+                                  i_name = `STATEMENTS-DELIMITED-BASIC` ).
+
+    assert_le_1_assoc_rets_empty( i_previous = me->statements-non_delimited-basic
+                                  i_name = `STATEMENTS-NON_DELIMITED-BASIC` ).
+
+  endmethod.
+  method data_sources_returned.
+
+    types: begin of statement,
+             val type string,
+             ds type string_table,
+           end of statement,
+           statements type standard table of statement with empty key.
+
+    "arrange
+    data(statements) = value statements( ( val = `SELECT * FROM dbtab1;`
+                                           ds = value #( ( `dbtab1` ) ) )
+                                         ( val = |SELECT{ cl_abap_char_utilities=>cr_lf }*{ cl_abap_char_utilities=>cr_lf }FROM{ cl_abap_char_utilities=>cr_lf }dbtab2{ cl_abap_char_utilities=>cr_lf }|
+                                           ds = value #( ( `dbtab2` ) ) )
+                                         ( val = |SELECT * FROM schema.dbtab3|
+                                           ds = value #( ( `dbtab3` ) ) )
+                                         ( val = |SELECT * FROM "schema"."dbtab4A" INNER JOIN "dbtab4B"|
+                                           ds = value #( ( `dbtab4A` )
+                                                         ( `dbtab4B` ) ) )
+                                         ( val = |WITH aux AS ( SELECT * FROM "dbtab5A" ) SELECT * FROM aux INNER JOIN schema."dbtab5B"|
+                                           ds = value #( ( `dbtab5A` )
+                                                         ( `aux` ) "technically not a ds that we care about buuuuuuuuut it shouldn't matter for the use case
+                                                         ( `dbtab5B` ) ) ) ).
+
+    loop at statements reference into data(statement).
+
+      "act & assert
+      cl_abap_unit_assert=>assert_equals( act = new sql_statement( i_sql_statement = statement->*-val
+                                                                   i_association_processor = new zcl_association_processor( )
+                                                                   i_processor = new cl_sql_statement( ) )->data_sources( )
+                                          exp = statement->*-ds
+                                          quit = if_abap_unit_constant=>quit-no
+                                          msg = |'{ statement->*-val }' has datasources: { concat_lines_of( table = statement->*-ds
+                                                                                                            sep = `, ` ) }| ).
+
+    endloop.
+
+  endmethod.
+  method assoc_mapping_added.
+
+    types: begin of statement,
+             original type string,
+             association type string,
+             join_fragment type string,
+             mapped type string,
+           end of statement,
+           statements type standard table of statement with empty key.
+
+    "arrange
+    data(join_clause) = `LEFT OUTER JOIN ON 1 = 1`.
+
+    data(statements) = value statements( ( original = `SELECT * FROM dbt`
+                                           mapped = value #( ) )
+                                         ( original = `SELECT "_assoc"."field" FROM entity`
+                                           association = `"_assoc"`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0"."field" FROM entity { join_clause }| )
+                                         ( original = `SELECT _assoc[ attrs ].field FROM entity WHERE _assoc[ attrs ].field IS NOT NULL;`
+                                           association = `_assoc[ attrs ]`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0".field FROM entity { join_clause } WHERE "=A0".field IS NOT NULL;| )
+                                         ( original = `SELECT _assoc.field FROM entity GROUP BY _assoc.field`
+                                           association = `_assoc`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0".field FROM entity { join_clause } GROUP BY "=A0".field| )
+                                         ( original = `SELECT _assoc[ attrs ].field FROM entity HAVING _assoc[ attrs ].field > 0`
+                                           association = `_assoc[ attrs ]`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0".field FROM entity { join_clause } HAVING "=A0".field > 0| )
+                                         ( original = `SELECT _assoc."field" FROM entity ORDER BY _assoc.field`
+                                           association = `_assoc`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0"."field" FROM entity { join_clause } ORDER BY "=A0".field| )
+                                         ( original = `SELECT _assoc.field FROM entity LIMIT 5;`
+                                           association = `_assoc`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0".field FROM entity { join_clause } LIMIT 5;| )
+                                         ( original = `SELECT "_assoc".field FROM entity WITH HINT( INDEX_JOIN )`
+                                           association = `"_assoc"`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0".field FROM entity { join_clause } WITH HINT( INDEX_JOIN )| )
+                                         ( original = `SELECT _assoc.field FROM entity WhErE _assoc.field IS NOT NULL gRoUp BY _assoc.field HAviNG cOUNt(*) > 0`
+                                           association = `_assoc`
+                                           join_fragment = join_clause
+                                           mapped = |SELECT "=A0".field FROM entity { join_clause } WhErE "=A0".field IS NOT NULL gRoUp BY "=A0".field HAviNG cOUNt(*) > 0| ) ).
+
+    loop at statements reference into data(statement).
+
+      "act & assert
+      cl_abap_unit_assert=>assert_equals( act = new _sql_statement_stub( i_sql_statement = statement->*-original
+                                                                         i_association_processor = new zcl_association_processor( )
+                                                                         i_processor = new cl_sql_statement( ) )->assoc_mapped_to_join_if_any( i_association = statement->*-association
+                                                                                                                                               i_join = statement->*-join_fragment )
+                                          exp = statement->*-mapped
+                                          quit = if_abap_unit_constant=>quit-no
+                                          msg = `Original: ` && statement->*-original ).
+
+    endloop.
+
+  endmethod.
+
+endclass.

--- a/src/native/zcl_2ui5_native_sql_console.clas.xml
+++ b/src/native/zcl_2ui5_native_sql_console.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
    <TPOOL>
     <item>
@@ -35,6 +36,12 @@
      <KEY>004</KEY>
      <ENTRY>Project on GitHub</ENTRY>
      <LENGTH>27</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>005</KEY>
+     <ENTRY>More than one unique path expression is not allowed</ENTRY>
+     <LENGTH>98</LENGTH>
     </item>
     <item>
      <ID>I</ID>
@@ -95,6 +102,12 @@
      <KEY>015</KEY>
      <ENTRY>No entries selected.</ENTRY>
      <LENGTH>40</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>016</KEY>
+     <ENTRY>More than one associations in a single expression path are not allowed</ENTRY>
+     <LENGTH>132</LENGTH>
     </item>
    </TPOOL>
   </asx:values>

--- a/src/native/zcl_association_processor.clas.abap
+++ b/src/native/zcl_association_processor.clas.abap
@@ -1,0 +1,181 @@
+class zcl_association_processor definition
+                                public
+                                create public.
+
+  public section.
+
+    interfaces: zif_association_processor.
+
+    aliases: map_association_to_join for zif_association_processor~map_association_to_join.
+
+    methods navigate_association
+              importing
+                i_data type if_data_preview=>ty_cds_assoc_nav_data optional
+              returning
+                value(r_val) type string
+              raising
+                cx_adt_rest.
+
+  protected section.
+
+endclass.
+class zcl_association_processor implementation.
+
+  METHOD navigate_association.
+
+    DATA lo_query_handler      TYPE REF TO cl_adt_dp_open_sql_handler.
+    DATA lx_dd_sobject_get     TYPE REF TO cx_dd_sobject_get.
+    DATA lx_dd_ddl_check       TYPE REF TO cx_dd_ddl_check.
+    DATA lo_dd_sobject_util    TYPE REF TO if_dd_sobject_util.
+    DATA lo_cds_stmt_gen       TYPE REF TO cl_adt_dp_cds_assoc_osql_map.
+    DATA lr_query_result       TYPE REF TO data.
+    DATA ls_table_det          TYPE if_data_preview=>ty_data_preview_table_data.
+    DATA ls_assoc_nav_data     TYPE if_data_preview=>ty_cds_assoc_nav_data.
+    DATA ls_selected_row_data  TYPE if_data_preview=>ty_table_cell_content.
+    DATA lt_source_data        TYPE cl_adt_dp_cds_assoc_osql_map=>ty_component_values.
+    DATA ls_source_data        TYPE cl_adt_dp_cds_assoc_osql_map=>ty_component_value.
+    DATA lt_field_details      TYPE ddentity_column_tab.
+    DATA ls_field_detail       TYPE ddentity_column.
+    DATA ls_sobjname           TYPE ddstrucobjname.
+    DATA lt_sobjnames          TYPE if_dd_sobject_types=>ty_t_sobjnames.
+    DATA lv_execution_time     TYPE string.
+    DATA lv_view_name          TYPE viewname.
+    DATA lv_tab_name           TYPE tabname.
+    DATA lv_subrc              LIKE sy-subrc.
+    DATA lv_error              TYPE symsgv.
+
+    FIELD-SYMBOLS:  <fs_table_col>     TYPE if_data_preview=>ty_column.
+
+    ls_assoc_nav_data = i_data.
+*    ls_assoc_nav_data = value #( cds_entity_name = `demo_cds_assoc_scarr`
+*                                 association_name = `_spfli`
+*                                 association_target = `demo_cds_assoc_spfli`
+*                                 selected_row_data = value #( ( name = 'CARRID'
+*                                                                value = 'AA' ) ) ).
+
+    TRANSLATE ls_assoc_nav_data-association_target TO UPPER CASE.
+    TRANSLATE ls_assoc_nav_data-association_name   TO UPPER CASE.
+    TRANSLATE ls_assoc_nav_data-cds_entity_name    TO UPPER CASE.
+
+    LOOP AT ls_assoc_nav_data-selected_row_data INTO ls_selected_row_data.
+      CLEAR ls_source_data.
+      ls_source_data-component_name = ls_selected_row_data-name.
+      ls_source_data-value = ls_selected_row_data-value.
+      APPEND ls_source_data TO lt_source_data.
+    ENDLOOP.
+
+    TRY.
+
+      CASE ls_assoc_nav_data-target_type.
+
+        WHEN 'B'.
+
+        WHEN 'T'.
+
+          lv_tab_name = ls_assoc_nav_data-association_target.
+          TRANSLATE lv_tab_name TO UPPER CASE.
+          CALL FUNCTION 'DB_EXISTS_TABLE'
+            EXPORTING
+              tabname = lv_tab_name
+            IMPORTING
+              subrc   = lv_subrc.
+          IF lv_subrc NE 0.
+            lv_error =  lv_view_name.
+            RAISE EXCEPTION TYPE cx_adt_datapreview_common
+              EXPORTING
+                textid = cx_adt_datapreview_common=>not_in_database
+                msgv1  = lv_error.
+
+          ENDIF.
+
+        WHEN 'V'.
+
+          lv_view_name = ls_assoc_nav_data-association_target.
+          TRANSLATE lv_view_name TO UPPER CASE.
+          CALL FUNCTION 'DB_EXISTS_VIEW'
+            EXPORTING
+              viewname = lv_view_name
+            IMPORTING
+              subrc    = lv_subrc.
+
+          IF lv_subrc NE 0.
+            lv_error =  lv_view_name.
+            RAISE EXCEPTION TYPE cx_adt_datapreview_common
+              EXPORTING
+                textid = cx_adt_datapreview_common=>not_in_database
+                msgv1  = lv_error.
+
+          ENDIF.
+
+        ENDCASE.
+
+        TRY.
+
+          CREATE OBJECT lo_cds_stmt_gen
+            EXPORTING
+              i_entity_name        = ls_assoc_nav_data-cds_entity_name
+              i_association_name   = ls_assoc_nav_data-association_name
+              i_target_data_source = ls_assoc_nav_data-association_target
+              i_source_data        = lt_source_data
+              i_param_values       = ls_assoc_nav_data-param_values.
+
+          lo_cds_stmt_gen->get_statement(
+*          lo_cds_stmt_gen->get_new_statement(
+            IMPORTING
+              e_statement           = r_val
+           ).
+
+        CATCH cx_dd_sobject INTO DATA(lx_dd_sobject).
+
+          RAISE EXCEPTION TYPE cx_adt_datapreview_common EXPORTING previous = lx_dd_sobject.
+
+        CATCH cx_dd_ddl_check INTO lx_dd_ddl_check.
+
+          RAISE EXCEPTION TYPE cx_adt_datapreview_common EXPORTING previous = lx_dd_ddl_check.
+
+        ENDTRY.
+
+      CATCH cx_dd_sobject_get INTO lx_dd_sobject_get.
+
+        RAISE EXCEPTION TYPE cx_adt_datapreview_common EXPORTING previous = lx_dd_sobject_get.
+
+    ENDTRY.
+
+  ENDMETHOD.
+  METHOD zif_association_processor~map_association_to_join.
+
+    constants statement_after_join type string value `(?i)\b(?:left|inner)\b.*` ##NO_TEXT.
+
+    if i_association is not initial.
+
+      try.
+
+        cl_dd_sobject_factory=>create_util( )->get_associations( exporting entitynames = i_potential_data_sources
+                                                                 importing associations = data(associations) ).
+
+        data(association_name) = segment( val = i_association
+                                          sep = `[`
+                                          index = 1 ).
+
+        data(assoc) = associations[ associationname = to_upper( association_name ) ].
+
+        data(assoc_select) = me->navigate_association( value #( cds_entity_name = assoc-entityname
+                                                                association_name = association_name
+                                                                association_target = assoc-entityname_t ) ).
+
+        r_val = match( val = assoc_select
+                       pcre = statement_after_join ).
+
+      catch cx_dd_sobject_get
+            cx_adt_rest into data(e).
+
+        raise exception type cx_sql_exception exporting sql_message = 'Error mapping the association'(001)
+                                                        previous = e.
+
+      endtry.
+
+    endif.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/native/zcl_association_processor.clas.locals_imp.abap
+++ b/src/native/zcl_association_processor.clas.locals_imp.abap
@@ -1,0 +1,494 @@
+*"* use this source file for the definition and implementation of
+*"* local helper classes, interface definitions and type
+*"* declarations
+INTERFACE lif_name_generator.
+  METHODS create_sql_view_name
+    RETURNING
+      VALUE(r_name) TYPE string .
+ENDINTERFACE.
+
+ class cl_adt_dp_cds_assoc_osql_map definition deferred.
+
+INTERFACE lif_data_source_utils.
+
+  METHODS:
+    get_columns
+      IMPORTING
+        VALUE(i_data_source_name) TYPE string
+        VALUE(i_data_source_kind) TYPE ddtypekind OPTIONAL
+      RETURNING
+        VALUE(r_columns)          TYPE ddentity_column_tab
+      RAISING
+        cx_dd_sobject_get,
+
+    get_client_field
+      IMPORTING
+        VALUE(i_data_source_name) TYPE string
+        VALUE(i_data_source_kind) TYPE ddtypekind OPTIONAL
+      RETURNING
+        VALUE(r_name)             TYPE string
+      RAISING
+        cx_dd_sobject_get.
+
+ENDINTERFACE.
+
+CLASS ltc_create_select_list DEFINITION DEFERRED.
+CLASS ltc_conv_statement_to_open_sql DEFINITION DEFERRED.
+CLASS ltc_get_ddl_source DEFINITION DEFERRED.
+CLASS ltc_create_where_clause DEFINITION DEFERRED.
+
+ CLASS lcl_name_generator DEFINITION CREATE PRIVATE FINAL.
+  PUBLIC SECTION.
+    INTERFACES: lif_name_generator.
+    CLASS-METHODS:
+      create
+        RETURNING VALUE(r_instance) TYPE REF TO lcl_name_generator.
+ENDCLASS.
+
+CLASS lcl_name_generator IMPLEMENTATION.
+
+  METHOD create.
+    CREATE OBJECT r_instance.
+  ENDMETHOD.
+
+  METHOD lif_name_generator~create_sql_view_name.
+    DATA(random_int) = cl_abap_random_int=>create(
+      EXPORTING
+        min  = 0
+        seed = CONV i( sy-uzeit ) ).
+
+    r_name = |Z{ random_int->get_next( ) }{ sy-uname(3) }|.
+  ENDMETHOD.
+
+ENDCLASS.
+
+CLASS ltc_data_source_utils DEFINITION DEFERRED.
+CLASS lcl_data_source_utils DEFINITION CREATE PRIVATE FRIENDS ltc_data_source_utils.
+
+  PUBLIC SECTION.
+    INTERFACES: lif_data_source_utils.
+    CLASS-METHODS:
+      create
+        RETURNING VALUE(r_instance) TYPE REF TO lcl_data_source_utils.
+
+  PRIVATE SECTION.
+
+    TYPES:
+      ty_tabl_fields TYPE STANDARD TABLE OF dd03p WITH EMPTY KEY,
+      ty_view_fields TYPE STANDARD TABLE OF dd27p WITH EMPTY KEY.
+
+    DATA dd_sobject_util TYPE REF TO if_dd_sobject_util.
+
+    METHODS:
+      read_entity_columns
+        IMPORTING
+          !i_entity_name  TYPE string
+        RETURNING
+          VALUE(r_result) TYPE ddentity_column_tab
+        RAISING
+          cx_dd_sobject_get,
+
+      tabl_fields_2_columns
+        IMPORTING
+          !i_fields       TYPE ty_tabl_fields
+        RETURNING
+          VALUE(r_result) TYPE ddentity_column_tab,
+
+      view_fields_2_columns
+        IMPORTING
+          !i_fields       TYPE ty_view_fields
+        RETURNING
+          VALUE(r_result) TYPE ddentity_column_tab.
+
+ENDCLASS.
+
+CLASS lcl_data_source_utils IMPLEMENTATION.
+
+  METHOD create.
+    CREATE OBJECT r_instance.
+    r_instance->dd_sobject_util = cl_dd_sobject_factory=>create_util( ).
+  ENDMETHOD.
+
+  METHOD lif_data_source_utils~get_columns.
+
+    DATA: type_name   TYPE typename,
+          tabl_fields TYPE ty_tabl_fields,
+          view_fields TYPE ty_view_fields,
+          object_name TYPE ddobjname.
+
+    CONDENSE i_data_source_name.
+
+    IF i_data_source_kind IS NOT SUPPLIED
+    OR i_data_source_kind IS INITIAL.
+      type_name = i_data_source_name.
+      CALL FUNCTION 'DDIF_TYPEINFO_GET'
+        EXPORTING
+          typename = type_name
+        IMPORTING
+          typekind = i_data_source_kind.
+    ENDIF.
+
+    CASE i_data_source_kind.
+
+      WHEN 'STOB'.
+
+        r_columns = read_entity_columns( i_data_source_name ).
+
+      WHEN 'TABL'.
+
+        object_name = i_data_source_name.
+        CALL FUNCTION 'DDIF_TABL_GET'
+          EXPORTING
+            name      = object_name
+          TABLES
+            dd03p_tab = tabl_fields.
+        r_columns = tabl_fields_2_columns( tabl_fields ).
+
+      WHEN 'VIEW'.
+
+        object_name = i_data_source_name.
+        CALL FUNCTION 'DDIF_VIEW_GET'
+          EXPORTING
+            name      = object_name
+          TABLES
+            dd27p_tab = view_fields.
+        r_columns = view_fields_2_columns( view_fields ).
+
+    ENDCASE.
+
+    DELETE r_columns WHERE fieldname IS INITIAL OR fieldname(1) = `.`.
+
+  ENDMETHOD.
+
+  METHOD read_entity_columns.
+
+    dd_sobject_util->get_columns(
+      EXPORTING
+        entitynames = VALUE if_dd_sobject_types=>ty_t_sobjnames(  ( |{ i_entity_name }| ) )
+      IMPORTING
+        columns = r_result ).
+
+  ENDMETHOD.
+
+  METHOD view_fields_2_columns.
+
+    DATA: column LIKE LINE OF r_result.
+
+    LOOP AT i_fields ASSIGNING FIELD-SYMBOL(<field>).
+      MOVE-CORRESPONDING <field> TO column.
+      column-entityname  = <field>-viewname.
+      column-description = <field>-ddtext.
+      column-fieldname = <field>-viewfield.
+      APPEND column TO r_result.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD tabl_fields_2_columns.
+
+    DATA: column LIKE LINE OF r_result.
+
+    LOOP AT i_fields ASSIGNING FIELD-SYMBOL(<field>).
+      MOVE-CORRESPONDING <field> TO column.
+      column-entityname  = <field>-tabname.
+      column-description = <field>-ddtext.
+      APPEND column TO r_result.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD lif_data_source_utils~get_client_field.
+
+    CONDENSE i_data_source_name.
+    DATA(columns) = lif_data_source_utils~get_columns( i_data_source_name = i_data_source_name
+                                                       i_data_source_kind = i_data_source_kind ).
+
+    CHECK columns IS NOT INITIAL.
+
+    DATA(first_column) = columns[ 1 ].
+    IF first_column-datatype = 'CLNT'.
+      r_name = to_upper( first_column-fieldname ).
+      CONDENSE r_name.
+    ENDIF.
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS cl_adt_dp_cds_assoc_osql_map DEFINITION
+
+  FINAL
+  CREATE PUBLIC
+  FRIENDS
+  ltc_create_select_list
+  ltc_conv_statement_to_open_sql
+  ltc_get_ddl_source
+  ltc_create_where_clause .
+
+  PUBLIC SECTION.
+
+    TYPES:
+      BEGIN OF ty_component_value,
+        component_name TYPE string,
+        value          TYPE string,
+      END OF ty_component_value .
+    TYPES:
+      ty_component_values TYPE STANDARD TABLE OF ty_component_value WITH EMPTY KEY .
+
+    METHODS constructor
+      IMPORTING
+        !i_entity_name        TYPE string
+        !i_association_name   TYPE string
+        !i_target_data_source TYPE string
+        !i_source_data        TYPE ty_component_values
+        !i_param_values       TYPE string
+      RAISING
+        cx_dd_sobject_get
+        cx_dd_sobject.
+    METHODS get_statement
+      EXPORTING
+        !e_statement TYPE string
+      RAISING
+        cx_dd_sobject_get
+        cx_dd_ddl_check.
+
+
+  PRIVATE SECTION.
+
+    TYPES:
+      BEGIN OF ty_open_sql_statement,
+        statement    TYPE string,
+        source_alias TYPE string,
+        target_alias TYPE string,
+      END OF ty_open_sql_statement .
+
+    DATA source_entity TYPE string .
+    DATA association_name TYPE string .
+    DATA target_data_source TYPE string .
+    DATA source_data TYPE ty_component_values .
+    DATA target_columns TYPE ddentity_column_tab .
+    DATA source_columns TYPE ddentity_column_tab .
+    DATA param_values   TYPE string.
+
+    DATA data_source_utils TYPE REF TO lif_data_source_utils.
+    DATA dd_sobject TYPE REF TO if_dd_sobject.
+    DATA name_generator TYPE REF TO lif_name_generator.
+
+    METHODS get_ddl_source
+      RETURNING
+        VALUE(r_source) TYPE ddddlsrcv
+      RAISING
+        cx_dd_sobject_get .
+
+    METHODS create_select_list
+      RETURNING
+        VALUE(r_select_list) TYPE string .
+
+    METHODS convert_statement
+      IMPORTING
+        !i_statement            TYPE string
+      RETURNING
+        VALUE(r_osql_statement) TYPE ty_open_sql_statement
+      RAISING
+        cx_dd_sobject_get.
+
+    METHODS get_db_select_statement
+      IMPORTING
+        i_ddl_source              TYPE ddddlsrcv
+      RETURNING
+        VALUE(r_select_statement) TYPE string
+      RAISING
+        cx_dd_ddl_check.
+
+    METHODS create_where_clause_w_client
+      IMPORTING
+        i_osql_statement      TYPE ty_open_sql_statement
+      RETURNING
+        VALUE(r_where_clause) TYPE string
+      RAISING
+        cx_dd_sobject_get.
+
+ENDCLASS.
+CLASS CL_ADT_DP_CDS_ASSOC_OSQL_MAP IMPLEMENTATION.
+
+  METHOD constructor.
+
+    dd_sobject = cl_dd_sobject_factory=>create( ).
+    data_source_utils = lcl_data_source_utils=>create( ).
+    name_generator = lcl_name_generator=>create( ).
+
+    source_entity = to_upper( i_entity_name ).
+    association_name = to_upper( i_association_name ).
+    target_data_source = to_upper( i_target_data_source ).
+    source_data = i_source_data.
+
+    LOOP AT source_data ASSIGNING FIELD-SYMBOL(<data>).
+      <data>-component_name = to_upper( <data>-component_name ).
+      CONDENSE <data>-component_name.
+    ENDLOOP.
+    param_values = i_param_values.
+
+    source_columns = data_source_utils->get_columns( i_data_source_name = source_entity i_data_source_kind = 'STOB' ).
+    target_columns = data_source_utils->get_columns( target_data_source ).
+
+  ENDMETHOD.
+  METHOD convert_statement.
+
+    TYPES: BEGIN OF ty_replacement,
+             old TYPE string,
+             new TYPE string,
+           END OF ty_replacement.
+
+    DATA: literal_replacements TYPE STANDARD TABLE OF ty_replacement WITH EMPTY KEY,
+          source_name          TYPE string,
+          submatch_1           TYPE string,
+          submatch_2           TYPE string,
+          submatch_3           TYPE string.
+
+    r_osql_statement-statement = i_statement.
+
+    "save the view name in src_name
+    if param_values is not initial .
+        DATA(source_alias_regex) = |FROM([[:space:]]+)([^[:space:]]+[[:space:]]+[^[:space:]])([[:space:]]+)([^[:space:]]+)|.
+        FIND FIRST OCCURRENCE OF REGEX source_alias_regex IN r_osql_statement-statement SUBMATCHES submatch_1 source_name submatch_3 r_osql_statement-source_alias.
+        REPLACE FIRST OCCURRENCE OF REGEX source_alias_regex IN r_osql_statement-statement WITH `FROM $2 AS $4`.
+
+        SPLIT r_osql_statement-statement AT '(' INTO TABLE data(itab).
+        SPLIT itab[ 2 ] AT ')' INTO TABLE data(itab2).
+        data src_name type string.
+        split source_name at '(' into TABLE data(itab_src).
+        src_name = itab_src[ 1 ].
+
+    else.
+        "Find and fix source alias definition
+        source_alias_regex = |FROM([[:space:]]+)([^[:space:]]+)([[:space:]]+)([^[:space:]]+)|.
+        FIND FIRST OCCURRENCE OF REGEX source_alias_regex IN r_osql_statement-statement SUBMATCHES submatch_1 source_name submatch_3 r_osql_statement-source_alias.
+        REPLACE FIRST OCCURRENCE OF REGEX source_alias_regex IN r_osql_statement-statement WITH `FROM $2 AS $4`.
+    endif.
+
+    "Find and fix target alias definition
+    DATA(target_alias_regex) = |JOIN([[:space:]]+)([^[:space:]]+)([[:space:]]+)([^[:space:]]+)|.
+    FIND FIRST OCCURRENCE OF REGEX target_alias_regex IN r_osql_statement-statement SUBMATCHES submatch_1 submatch_2 submatch_3 r_osql_statement-target_alias.
+    REPLACE FIRST OCCURRENCE OF REGEX target_alias_regex IN r_osql_statement-statement WITH `JOIN $2 AS $4`.
+
+    "Replace src_name( 'val' ) in parameter values with src_name( param = param_value )
+    if param_values is not initial.
+         data src_name_parameters type string.
+         concatenate 'FROM ' src_name param_values into src_name_parameters respecting blanks.
+         REPLACE FIRST OCCURRENCE OF regex `FROM([[:space:]]+)([^[:space:]]+)\([^\)]*\)` in r_osql_statement-statement with src_name_parameters.
+    endif.
+
+  ENDMETHOD.
+  METHOD create_select_list.
+
+    LOOP AT target_columns INTO DATA(column).
+      IF sy-tabix = 1.
+        r_select_list = |{ association_name }.{ column-fieldname }|.
+        CONTINUE.
+      ENDIF.
+
+      r_select_list = r_select_list && |, { association_name }.{ column-fieldname }|.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+  METHOD create_where_clause_w_client.
+
+    " Create filter for source fields
+    LOOP AT source_data INTO DATA(component).
+
+      IF r_where_clause IS NOT INITIAL.
+        r_where_clause = r_where_clause && ` AND `.
+      ENDIF.
+      REPLACE ALL OCCURRENCES OF `'` IN component-value WITH `''`. "Escape single quotes
+      r_where_clause = |{ r_where_clause }{ i_osql_statement-source_alias }.{ component-component_name } = '{ component-value }'|.
+
+    ENDLOOP.
+
+    " Add WHERE keyword
+    IF r_where_clause IS NOT INITIAL.
+      r_where_clause = `WHERE ` && r_where_clause.
+    ENDIF.
+
+  ENDMETHOD.
+  METHOD get_db_select_statement.
+
+    DATA(ddl_handler) = cl_dd_ddl_handler_factory=>create( ).
+
+    "does this method exist in older releases?
+    r_select_statement = ddl_handler->generate_create_statement(
+      EXPORTING
+        iv_ddlname           = i_ddl_source-ddlname
+*        iv_prid              = -1
+        is_source            = i_ddl_source
+*        iv_state             = 'A'
+*        iv_dbsys             = SY-DBSYS
+*        checkmode            = cl_dd_cds_check=>co_dd_checkmode-online
+*        io_parser_src_filter = io_parser_src_filter
+    ).
+
+***    ddl_handler->get_select(
+***      EXPORTING
+***        name            = i_ddl_source-ddlname
+***        ddlsrcv_wa      = i_ddl_source
+***      IMPORTING
+***        select_stmt     = r_select_statement ).
+
+  ENDMETHOD.
+  METHOD get_ddl_source.
+
+    r_source-ddlname = name_generator->create_sql_view_name( ).
+
+    dd_sobject->read(
+      EXPORTING
+        sobjnames         = VALUE if_dd_sobject_types=>ty_t_sobjnames( ( |{ source_entity }| ) )
+      IMPORTING
+        dd02bndv_tab      = DATA(structure_headers)
+    ).
+
+    IF structure_headers[ 1 ]-clientfield IS INITIAL.
+      r_source-source = |@ClientDependent: 'false'|.
+    ENDIF.
+
+    DATA(select_list) = create_select_list( ).
+    if structure_headers[ 1 ]-with_parameters = 'X'.
+        data parameters type string.
+        concatenate ' ' parameters into parameters.
+        parameters = param_values.
+        replace all occurrences of '=' in parameters with ':'.
+        r_source-source = |{ r_source-source } | &&
+                          |@AbapCatalog.sqlViewName: '{ r_source-ddlname }' | &&
+                          |DEFINE VIEW { r_source-ddlname && `E` } AS SELECT FROM { source_entity } { parameters } \{ | &&
+                          |{ select_list } \}|.
+    else.
+        r_source-source = |{ r_source-source } | &&
+                          |@AbapCatalog.sqlViewName: '{ r_source-ddlname }' | &&
+                          |DEFINE VIEW { r_source-ddlname && `E` } AS SELECT FROM { source_entity } \{ | &&
+                          |{ select_list } \}|.
+    endif.
+
+  ENDMETHOD.
+  METHOD get_statement.
+
+    DATA(ddl_source) = get_ddl_source( ).
+
+    DATA(db_select_statement) = get_db_select_statement( ddl_source ).
+
+***    DATA(osql_statement) = convert_statement_to_open_sql( db_select_statement ).
+    DATA(osql_statement) = convert_statement( db_select_statement ). "no thanks
+
+
+***    DATA(where_clause) = create_where_clause( osql_statement ).
+    DATA(where_clause) = create_where_clause_w_client( osql_statement ).
+
+    e_statement = osql_statement-statement && ` ` && where_clause.
+
+***    REMOVE_MANDT(
+***      changing
+***        E_STATEMENT = e_statement
+***    ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/native/zcl_association_processor.clas.testclasses.abap
+++ b/src/native/zcl_association_processor.clas.testclasses.abap
@@ -1,0 +1,479 @@
+*"* use this source file for your ABAP unit test classes
+CLASS ltc_create_select_list DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      co_empty_entity_name        TYPE string VALUE ``,
+      co_empty_target_data_source TYPE string VALUE ``,
+      co_association_name         TYPE string VALUE `ASSOCIATION_NAME`.
+    DATA:
+      co_empty_source_data        TYPE cl_adt_dp_cds_assoc_osql_map=>ty_component_values.
+
+    DATA:
+      act_select_list TYPE string,
+      cut             TYPE REF TO cl_adt_dp_cds_assoc_osql_map.
+
+    METHODS: setup RAISING cx_static_check,
+
+      no_columns FOR TESTING RAISING cx_static_check,
+      one_column FOR TESTING RAISING cx_static_check,
+      two_columns FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltc_create_select_list IMPLEMENTATION.
+
+  METHOD setup.
+    CLEAR co_empty_source_data.
+
+    CREATE OBJECT cut
+      EXPORTING
+        i_entity_name        = co_empty_entity_name
+        i_association_name   = co_association_name
+        i_target_data_source = co_empty_target_data_source
+        i_source_data        = co_empty_source_data
+        i_param_values       = ''.
+  ENDMETHOD.
+
+  METHOD no_columns.
+
+    CLEAR cut->target_columns.
+
+    act_select_list = cut->create_select_list( ).
+
+    cl_abap_unit_assert=>assert_initial( act_select_list ).
+
+  ENDMETHOD.
+
+  METHOD one_column.
+
+    cut->target_columns = VALUE #( ( fieldname = `FIELDNAME` ) ).
+
+    act_select_list = cut->create_select_list( ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_select_list
+                                        exp = |{ co_association_name }.FIELDNAME| ).
+
+  ENDMETHOD.
+
+  METHOD two_columns.
+
+    cut->target_columns = VALUE #( ( fieldname = `FIRST_FIELDNAME` ) ( fieldname = `SECOND_FIELDNAME` ) ).
+
+    act_select_list = cut->create_select_list( ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_select_list
+                                        exp = |{ co_association_name }.FIRST_FIELDNAME, { co_association_name }.SECOND_FIELDNAME| ).
+
+  ENDMETHOD.
+
+
+
+ENDCLASS.
+
+CLASS ltd_dd_sobject DEFINITION FINAL FOR TESTING .
+  PUBLIC SECTION.
+    INTERFACES: if_dd_sobject PARTIALLY IMPLEMENTED.
+    DATA: structure_headers TYPE dd02bndvtab.
+ENDCLASS.
+
+
+CLASS ltd_dd_sobject IMPLEMENTATION.
+  METHOD if_dd_sobject~read.
+    dd02bndv_tab = structure_headers.
+  ENDMETHOD.
+ENDCLASS.
+
+
+CLASS ltd_name_generator DEFINITION FINAL FOR TESTING .
+  PUBLIC SECTION.
+    INTERFACES: lif_name_generator PARTIALLY IMPLEMENTED.
+    DATA: sql_view_name TYPE string.
+ENDCLASS.
+
+
+CLASS ltd_name_generator IMPLEMENTATION.
+  METHOD lif_name_generator~create_sql_view_name.
+    r_name = sql_view_name.
+  ENDMETHOD.
+ENDCLASS.
+
+
+CLASS ltc_get_ddl_source DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      co_target_entity_name       TYPE string VALUE `TARGET_ENTITY_NAME`,
+      co_source_entity_name       TYPE string VALUE `SOURCE_ENTITY_NAME`,
+      co_empty_target_data_source TYPE string VALUE ``,
+      co_association_name         TYPE string VALUE `ASSOCIATION_NAME`,
+      co_sql_view_name            TYPE string VALUE `SQL_VIEW_NAME`.
+    DATA:
+      co_empty_source_data        TYPE cl_adt_dp_cds_assoc_osql_map=>ty_component_values.
+
+    DATA:
+      td_dd_sobject     TYPE REF TO ltd_dd_sobject,
+      td_name_generator TYPE REF TO ltd_name_generator,
+      cut               TYPE REF TO cl_adt_dp_cds_assoc_osql_map,
+      act_ddl_source    TYPE ddddlsrcv,
+      exp_source        TYPE ddddlsource.
+    METHODS:
+      setup RAISING cx_static_check,
+
+      simple_association_no_filter FOR TESTING RAISING cx_static_check,
+      simple_association_with_filter FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltc_get_ddl_source IMPLEMENTATION.
+
+  METHOD setup.
+
+    CREATE OBJECT cut
+      EXPORTING
+        i_entity_name        = co_source_entity_name
+        i_association_name   = co_association_name
+        i_target_data_source = co_empty_target_data_source
+        i_source_data        = co_empty_source_data
+        i_param_values       = ''.
+
+    CREATE OBJECT td_dd_sobject.
+    cut->dd_sobject = td_dd_sobject.
+
+    CREATE OBJECT td_name_generator.
+    cut->name_generator = td_name_generator.
+
+  ENDMETHOD.
+
+  METHOD simple_association_no_filter.
+
+    td_dd_sobject->structure_headers = VALUE #( ( clientfield = 'MANDT' ) ).
+
+    td_name_generator->sql_view_name = co_sql_view_name.
+
+    cut->target_columns = VALUE #( ( entityname = co_target_entity_name fieldname = 'FIRST_FIELD' )
+                                   ( entityname = co_target_entity_name fieldname = 'SECOND_FIELD' )
+                                   ( entityname = co_target_entity_name fieldname = 'THIRD_FIELD' )
+                                 ).
+
+    act_ddl_source = cut->get_ddl_source( ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_ddl_source-ddlname exp = co_sql_view_name ).
+
+    exp_source =  |@AbapCatalog.sqlViewName: '{ co_sql_view_name }' | &&
+                  |define view { co_sql_view_name && `E` } as select from { co_source_entity_name } \{ | &&
+                  |{ co_association_name }.FIRST_FIELD, { co_association_name }.SECOND_FIELD, { co_association_name }.THIRD_FIELD \}|.
+
+    CONDENSE: exp_source, act_ddl_source-source.
+    exp_source = to_upper( exp_source ).
+    act_ddl_source-source = to_upper( act_ddl_source-source ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_ddl_source-source exp = exp_source ).
+
+  ENDMETHOD.
+
+  METHOD simple_association_with_filter.
+
+    td_dd_sobject->structure_headers = VALUE #( ( clientfield = 'MANDT' ) ).
+
+    td_name_generator->sql_view_name = co_sql_view_name.
+
+    cut->target_columns = VALUE #( ( entityname = co_target_entity_name fieldname = 'TARGET_FIELD' ) ).
+
+    cut->source_data = VALUE #( ( component_name = 'CLNT' value = '000' )
+                                ( component_name = 'KEY'  value = 'A' )
+                                ( component_name = 'FIELD' value = 'Z' )
+                              ).
+
+    cut->source_columns = VALUE #( ( entityname = co_source_entity_name fieldname = 'CLNT' keyflag = 'X' datatype = 'CLNT' )
+                                   ( entityname = co_source_entity_name fieldname = 'KEY' keyflag = 'X' )
+                                   ( entityname = co_source_entity_name fieldname = 'FIELD' )
+                                 ).
+
+    act_ddl_source = cut->get_ddl_source( ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_ddl_source-ddlname exp = co_sql_view_name ).
+
+    exp_source =  |@AbapCatalog.sqlViewName: '{ co_sql_view_name }' | &&
+                  |define view { co_sql_view_name && `E` } as select from { co_source_entity_name } \{ | &&
+                  |{ co_association_name }.TARGET_FIELD \}|.
+
+    CONDENSE: exp_source, act_ddl_source-source.
+    exp_source = to_upper( exp_source ).
+    act_ddl_source-source = to_upper( act_ddl_source-source ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_ddl_source-source exp = exp_source ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltd_data_source_utils DEFINITION FINAL FOR TESTING.
+
+  PUBLIC SECTION.
+    INTERFACES: lif_data_source_utils PARTIALLY IMPLEMENTED.
+
+    METHODS:
+
+      set_client_field
+        IMPORTING
+          i_name TYPE string.
+
+  PRIVATE SECTION.
+    DATA: client_field TYPE string.
+
+ENDCLASS.
+
+
+CLASS ltd_data_source_utils IMPLEMENTATION.
+
+  METHOD set_client_field.
+    client_field = i_name.
+  ENDMETHOD.
+
+  METHOD lif_data_source_utils~get_client_field.
+    r_name = client_field.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltc_conv_statement_to_open_sql DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      co_target_entity_name     TYPE string VALUE `TARGET_ENTITY_NAME`,
+      co_source_entity_name     TYPE string VALUE `SOURCE_ENTITY_NAME`,
+      co_empty_association_name TYPE string VALUE ``.
+    DATA:
+      co_empty_source_data        TYPE cl_adt_dp_cds_assoc_osql_map=>ty_component_values.
+
+    DATA:
+      td_dd_sobject        TYPE REF TO ltd_dd_sobject,
+      td_name_generator    TYPE REF TO ltd_name_generator,
+      td_data_source_utils TYPE REF TO ltd_data_source_utils,
+      cut                  TYPE REF TO cl_adt_dp_cds_assoc_osql_map.
+
+
+    METHODS: setup RAISING cx_static_check,
+      setup_stubs RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltc_conv_statement_to_open_sql IMPLEMENTATION.
+
+  METHOD setup.
+    CLEAR co_empty_source_data.
+
+    CREATE OBJECT cut
+      EXPORTING
+        i_entity_name        = co_source_entity_name
+        i_association_name   = co_empty_association_name
+        i_target_data_source = co_target_entity_name
+        i_source_data        = co_empty_source_data
+        i_param_values       = ''.
+  ENDMETHOD.
+
+  METHOD setup_stubs.
+    CREATE OBJECT td_dd_sobject.
+    cut->dd_sobject = td_dd_sobject.
+
+    CREATE OBJECT td_name_generator.
+    cut->name_generator = td_name_generator.
+
+    CREATE OBJECT td_data_source_utils.
+    cut->data_source_utils = td_data_source_utils.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltc_create_where_clause DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      co_empty_entity_name        TYPE string VALUE ``,
+      co_empty_target_data_source TYPE string VALUE ``,
+      co_empty_association_name   TYPE string VALUE ``.
+    DATA:
+      co_empty_source_data        TYPE cl_adt_dp_cds_assoc_osql_map=>ty_component_values.
+
+    DATA:
+      cut               TYPE REF TO cl_adt_dp_cds_assoc_osql_map.
+
+    METHODS: setup RAISING cx_static_check.
+
+
+ENDCLASS.
+
+
+CLASS ltc_create_where_clause IMPLEMENTATION.
+
+  METHOD setup.
+    CLEAR co_empty_source_data.
+
+    CREATE OBJECT cut
+      EXPORTING
+        i_entity_name        = co_empty_entity_name
+        i_association_name   = co_empty_association_name
+        i_target_data_source = co_empty_target_data_source
+        i_source_data        = co_empty_source_data
+        i_param_values       = ''.
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltd_dd_sobject_util DEFINITION FINAL FOR TESTING.
+  PUBLIC SECTION.
+    INTERFACES: if_dd_sobject_util PARTIALLY IMPLEMENTED.
+    DATA: columns TYPE ddentity_column_tab.
+ENDCLASS.
+
+
+CLASS ltd_dd_sobject_util IMPLEMENTATION.
+  METHOD if_dd_sobject_util~get_columns.
+    columns = me->columns.
+  ENDMETHOD.
+ENDCLASS.
+
+CLASS ltc_data_source_utils DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+
+    CONSTANTS: co_empty_data_source_name TYPE string VALUE ``,
+               co_data_source_kind_stob  TYPE ddtypekind VALUE 'STOB'.
+
+    DATA: cut                TYPE REF TO lcl_data_source_utils,
+          td_dd_sobject_util TYPE REF TO ltd_dd_sobject_util,
+          act_columns        TYPE ddentity_column_tab,
+          act_client_field   TYPE string.
+
+    METHODS:
+
+      setup RAISING cx_static_check,
+
+      viewfield_mapped_to_fieldname FOR TESTING RAISING cx_static_check,
+      include_field_is_ignored FOR TESTING RAISING cx_static_check,
+      clnt_set_as_client_field FOR TESTING RAISING cx_static_check,
+      non_clnt_not_set_as_clnt_field FOR TESTING RAISING cx_static_check,
+      clnt_field_must_be_first_field FOR TESTING RAISING cx_static_check,
+      first_clnt_field_is_used FOR TESTING RAISING cx_static_check,
+      no_columns_clnt_field_empty FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltc_data_source_utils IMPLEMENTATION.
+
+  METHOD setup.
+    cut = lcl_data_source_utils=>create( ).
+
+    CREATE OBJECT td_dd_sobject_util.
+    cut->dd_sobject_util = td_dd_sobject_util.
+
+  ENDMETHOD.
+
+  METHOD viewfield_mapped_to_fieldname.
+
+    DATA(td_view_fields) = VALUE lcl_data_source_utils=>ty_view_fields( ( fieldname = 'FIELDNAME' viewfield = 'VIEWFIELD' ) ).
+
+    DATA(act_columns) = cut->view_fields_2_columns( td_view_fields ).
+
+    cl_abap_unit_assert=>assert_not_initial( act_columns ).
+
+    cl_abap_unit_assert=>assert_equals(  act = act_columns[ 1 ]-fieldname
+                                         exp = 'VIEWFIELD' ).
+
+  ENDMETHOD.
+
+  METHOD include_field_is_ignored.
+
+    td_dd_sobject_util->columns = VALUE #( ( fieldname = '.INCLUDE' ) ).
+
+    act_columns = cut->lif_data_source_utils~get_columns( i_data_source_name = co_empty_data_source_name
+                                                          i_data_source_kind = co_data_source_kind_stob ).
+
+    cl_abap_unit_assert=>assert_initial( act_columns ).
+
+  ENDMETHOD.
+
+  METHOD clnt_set_as_client_field.
+
+    td_dd_sobject_util->columns = VALUE #( ( fieldname = 'CLIENT_FIELD' keyflag = 'X' datatype = 'CLNT' ) ).
+
+    act_client_field = cut->lif_data_source_utils~get_client_field( i_data_source_name = co_empty_data_source_name
+                                                                    i_data_source_kind = co_data_source_kind_stob ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_client_field exp = 'CLIENT_FIELD' ).
+
+  ENDMETHOD.
+
+  METHOD non_clnt_not_set_as_clnt_field.
+
+    td_dd_sobject_util->columns = VALUE #( ( fieldname = 'NON_CLIENT_FIELD' keyflag = 'X' datatype = 'CHAR1' ) ).
+
+    act_client_field = cut->lif_data_source_utils~get_client_field( i_data_source_name = co_empty_data_source_name
+                                                                    i_data_source_kind = co_data_source_kind_stob ).
+
+    cl_abap_unit_assert=>assert_initial( act_client_field ).
+
+  ENDMETHOD.
+
+  METHOD clnt_field_must_be_first_field.
+
+    td_dd_sobject_util->columns = VALUE #(
+                                            ( fieldname = 'NON_CLIENT_FIELD' keyflag = 'X' datatype = 'CHAR1' )
+                                            ( fieldname = 'CLIENT_FIELD' keyflag = 'X' datatype = 'CLNT' )
+                                         ).
+
+    act_client_field = cut->lif_data_source_utils~get_client_field( i_data_source_name = co_empty_data_source_name
+                                                                    i_data_source_kind = co_data_source_kind_stob ).
+
+    cl_abap_unit_assert=>assert_initial( act_client_field ).
+
+  ENDMETHOD.
+
+  METHOD first_clnt_field_is_used.
+
+    td_dd_sobject_util->columns = VALUE #(
+                                            ( fieldname = 'FIRST_CLIENT_FIELD' keyflag = 'X' datatype = 'CLNT' )
+                                            ( fieldname = 'SECOND_CLIENT_FIELD' keyflag = 'X' datatype = 'CLNT' )
+                                         ).
+
+    act_client_field = cut->lif_data_source_utils~get_client_field( i_data_source_name = co_empty_data_source_name
+                                                                    i_data_source_kind = co_data_source_kind_stob ).
+
+    cl_abap_unit_assert=>assert_equals( act = act_client_field exp = 'FIRST_CLIENT_FIELD' ).
+
+  ENDMETHOD.
+
+  METHOD no_columns_clnt_field_empty.
+
+    act_client_field = cut->lif_data_source_utils~get_client_field( i_data_source_name = co_empty_data_source_name
+                                                                    i_data_source_kind = co_data_source_kind_stob ).
+
+    cl_abap_unit_assert=>assert_initial( act_client_field ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/native/zcl_association_processor.clas.xml
+++ b/src/native/zcl_association_processor.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ASSOCIATION_PROCESSOR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>.</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>001</KEY>
+     <ENTRY>Error mapping the association</ENTRY>
+     <LENGTH>58</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/native/zif_association_processor.intf.abap
+++ b/src/native/zif_association_processor.intf.abap
@@ -1,0 +1,14 @@
+interface zif_association_processor public.
+
+  types t_data_sources type if_dd_sobject_types=>ty_t_sobjnames.
+
+  methods map_association_to_join
+            importing
+              i_potential_data_sources type zif_association_processor=>t_data_sources
+              i_association type string
+            returning
+              value(r_val) type string
+            raising
+              cx_sql_exception.
+
+endinterface.

--- a/src/native/zif_association_processor.intf.xml
+++ b/src/native/zif_association_processor.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ASSOCIATION_PROCESSOR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Association Processor</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Associations for ABAP CDS are not materialized in the db, but old versions of AS ABAP had an ADT service to get the corresponding JOIN clause (to be used from the SQL console). This commit maps a single association path into its corresponding JOIN behind the scenes to be able to use associations to a limited degree. 
Path expression attributes, CTEs, and set operators are currently not supported but a query like the following should work without any problems: 

![image](https://github.com/user-attachments/assets/205db5da-34b5-4d21-b7d5-7ebab6123aa0)
