### PR TITLE
Rename popup classes to use consistent naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ SQL Console in Your Browser – No Need for Eclipse or SAP GUI Installation
 * S/4 Private Cloud or On-Premise (ABAP for Cloud, Standard ABAP)
 * SAP NetWeaver AS ABAP 7.50 or higher (Standard ABAP)
 
+#### Dependencies
+* [abap2UI5](https://github.com/abap2UI5/abap2UI5)
+* [popups](https://github.com/abap2UI5-addons/popups)
+
 #### Credits
 * Logic for Query to ABAP SQL Translation used from [ZTOAD](https://github.com/marianfoo/ztoad), integrated by [choper725](https://github.com/choper725)
 

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -14,6 +14,11 @@
     "files": "/src/**/*.*"
   },
   {
+    "url": "https://github.com/abap2UI5-addons/popups",
+    "folder": "/popups",
+    "files": "/src/**/*.*"
+  },
+  {
     "url": "https://github.com/abap2UI5-addons/custom-controls",
     "folder": "/customcontrols",
     "files": "/src/**/*.*"

--- a/src/abap/z2ui5_sql_cl_app_01.clas.abap
+++ b/src/abap/z2ui5_sql_cl_app_01.clas.abap
@@ -124,7 +124,7 @@ CLASS z2ui5_sql_cl_app_01 DEFINITION PUBLIC.
     METHODS preview_on_filter_clear.
     METHODS z2ui5_on_callback_pop_confirm
       IMPORTING
-        io_popup TYPE REF TO z2ui5_cl_pop_to_confirm.
+        io_popup TYPE REF TO z2ui5_cl_popup_to_confirm.
     METHODS history_on_load.
     METHODS history_db_save.
     METHODS z2ui5_on_init_set_app.
@@ -215,7 +215,7 @@ CLASS z2ui5_sql_cl_app_01 IMPLEMENTATION.
       client->message_box_display( `No history entries found. No action needed.` ).
       RETURN.
     ENDIF.
-    ms_control-callback_pop_history_clear = client->nav_app_call( z2ui5_cl_pop_to_confirm=>factory( `Delete all history entries from database?` ) ).
+    ms_control-callback_pop_history_clear = client->nav_app_call( z2ui5_cl_popup_to_confirm=>factory( `Delete all history entries from database?` ) ).
 
   ENDMETHOD.
 
@@ -517,7 +517,7 @@ CLASS z2ui5_sql_cl_app_01 IMPLEMENTATION.
         z2ui5_on_event(  ).
 
       CATCH cx_root INTO DATA(x).
-        client->nav_app_call( z2ui5_cl_pop_error=>factory( x ) ).
+        client->nav_app_call( z2ui5_cl_popup_error=>factory( x ) ).
     ENDTRY.
   ENDMETHOD.
 
@@ -525,14 +525,14 @@ CLASS z2ui5_sql_cl_app_01 IMPLEMENTATION.
   METHOD z2ui5_on_callback.
 
     TRY.
-        DATA(lo_popup_confirm) = CAST z2ui5_cl_pop_to_confirm( client->get_app( client->get( )-s_draft-id_prev_app ) ).
+        DATA(lo_popup_confirm) = CAST z2ui5_cl_popup_to_confirm( client->get_app( client->get( )-s_draft-id_prev_app ) ).
         z2ui5_on_callback_pop_confirm( lo_popup_confirm ).
         RETURN.
       CATCH cx_root.
     ENDTRY.
 
     TRY.
-        DATA(lo_popup_range) = CAST z2ui5_cl_pop_get_range_m( client->get_app( client->get( )-s_draft-id_prev_app ) ).
+        DATA(lo_popup_range) = CAST z2ui5_cl_popup_get_range_m( client->get_app( client->get( )-s_draft-id_prev_app ) ).
         IF lo_popup_range->result( )-check_confirmed = abap_true.
           ms_draft-s_preview-t_filter = lo_popup_range->result( )-t_filter.
           preview_on_filter( ).
@@ -584,7 +584,7 @@ CLASS z2ui5_sql_cl_app_01 IMPLEMENTATION.
         z2ui5_on_init_set_app( ).
 
       WHEN `PREVIEW_FILTER`.
-        client->nav_app_call( z2ui5_cl_pop_get_range_m=>factory( ms_draft-s_preview-t_filter ) ).
+        client->nav_app_call( z2ui5_cl_popup_get_range_m=>factory( ms_draft-s_preview-t_filter ) ).
 
       WHEN `PREVIEW_CLEAR_FILTER`.
         preview_on_filter_clear( ).

--- a/src/native/zcl_2ui5_native_sql_console.clas.abap
+++ b/src/native/zcl_2ui5_native_sql_console.clas.abap
@@ -76,7 +76,7 @@ class zcl_2ui5_native_sql_console implementation.
 
       t->undo( ).
 
-      me->a_ui5_client->nav_app_call( z2ui5_cl_pop_error=>factory( e ) ).
+      me->a_ui5_client->nav_app_call( z2ui5_cl_popup_error=>factory( e ) ).
 
     endtry.
 

--- a/src/native/zcl_2ui5_native_sql_console.clas.locals_imp.abap
+++ b/src/native/zcl_2ui5_native_sql_console.clas.locals_imp.abap
@@ -227,7 +227,7 @@ class user_approval definition
 
   protected section.
 
-    data a_confirmation_popup type ref to z2ui5_cl_pop_to_confirm.
+    data a_confirmation_popup type ref to z2ui5_cl_popup_to_confirm.
 
 endclass.
 interface popup_dialog.
@@ -249,7 +249,7 @@ class error_acknowledged_interaction definition
 
   protected section.
 
-    data a_downcasted_ref type ref to z2ui5_cl_pop_error ##NEEDED. "as a safeguard that we are actually handling the intended popup
+    data a_downcasted_ref type ref to z2ui5_cl_popup_error ##NEEDED. "as a safeguard that we are actually handling the intended popup
 
 endclass.
 class sql_statement definition
@@ -744,7 +744,7 @@ class on_delete_history_items implementation.
 
       else.
 
-        i_ui5_client->nav_app_call( z2ui5_cl_pop_to_confirm=>factory( conv #( 'Delete selected history entries from database?'(013) ) ) ).
+        i_ui5_client->nav_app_call( z2ui5_cl_popup_to_confirm=>factory( conv #( 'Delete selected history entries from database?'(013) ) ) ).
 
         state->event_awaiting_response = me->event_name( ).
 
@@ -860,7 +860,7 @@ class error_acknowledged_interaction implementation.
   endmethod.
   method ui_interaction~id.
 
-    r_val = `\CLASS=Z2UI5_CL_POP_ERROR`.
+    r_val = `\CLASS=Z2UI5_CL_POPUP_ERROR`.
 
   endmethod.
 


### PR DESCRIPTION
## Summary
This PR updates all references to popup classes to use a consistent naming convention, renaming classes from `z2ui5_cl_pop_*` to `z2ui5_cl_popup_*` throughout the codebase.

## Key Changes
- Renamed class references:
  - `z2ui5_cl_pop_to_confirm` → `z2ui5_cl_popup_to_confirm`
  - `z2ui5_cl_pop_error` → `z2ui5_cl_popup_error`
  - `z2ui5_cl_pop_get_range_m` → `z2ui5_cl_popup_get_range_m`
- Updated all type declarations and method signatures in `z2ui5_sql_cl_app_01` class
- Updated all type declarations and method implementations in `zcl_2ui5_native_sql_console` class and its local implementations
- Updated class identifier string in `error_acknowledged_interaction` from `Z2UI5_CL_POP_ERROR` to `Z2UI5_CL_POPUP_ERROR`
- Added dependency reference to the `popups` addon in `abaplint.jsonc`
- Updated README.md to document the new dependency on the popups addon

## Implementation Details
- All changes maintain backward compatibility at the functional level - only class names are updated
- The renaming is applied consistently across both main application code and native SQL console implementation
- The popup addon is now explicitly declared as a dependency in the project configuration

https://claude.ai/code/session_01EUm2VFnKDYma7WNGyBT3qb